### PR TITLE
binary installation instructions for NixOS

### DIFF
--- a/content/installation/installing-binary-dependencies.md
+++ b/content/installation/installing-binary-dependencies.md
@@ -151,3 +151,24 @@ On Linux and OSX, you can run
 `echo $HOME/ghc-mod-sandbox/bin/*`
 in the terminal to get actual paths to all executables, if not sure what those should look like.
 {{%/notice%}}
+
+## With `NixOS`
+
+With NixOS, haskell binaries are available in the
+[haskellPackages](https://nixos.org/nixpkgs/manual/#users-guide-to-the-haskell-infrastructure)
+attribute set.
+
+{{%notice info%}}
+You can query the list of all available haskell packages with:
+```bash
+nix-env -f "<nixpkgs>" -qaP -A haskellPackages
+```
+{{%/notice%}}
+
+Install `ghc-mod` and `stylish-haskell`.
+
+```bash
+nix-env -f "<nixpkgs>" -iA haskellPackages.ghc-mod haskellPackages.stylish-haskell
+```
+
+You should now have `ghc-mod` and `stylish-haskell` available in your profile.


### PR DESCRIPTION
I had issues building the docs and verifying the change: 

```shell
> $ make
node_modules/.bin/lunr-hugo -i "content/**/*.md" -o static/json/search.json -l yaml
rm -rf public/*
hugo
Started building sites ...
ERROR 2017/12/12 22:26:01 Unable to locate template for shortcode "notice" in page "core-packages/language-haskell.md"
ERROR 2017/12/12 22:26:01 Unable to locate template for shortcode "notice" in page "extra-packages/ide-haskell-hoogle.md"
ERROR 2017/12/12 22:26:01 Unable to locate template for shortcode "notice" in page "installation/installing-packages.md"
ERROR 2017/12/12 22:26:01 Unable to locate template for shortcode "notice" in page "core-packages/ide-haskell.md"
ERROR 2017/12/12 22:26:01 Unable to locate template for shortcode "notice" in page "installation/installing-binary-dependencies.md"
ERROR 2017/12/12 22:26:01 Unable to locate template for shortcode "notice" in page "core-packages/haskell-ghc-mod.md"
ERROR 2017/12/12 22:26:01 Error while rendering "home": template: index.html:1:3: executing "index.html" at <partial "header.html...>: error calling partial: Partial "header.html" not found
make: *** [Makefile:6: build] Error 255
```